### PR TITLE
weak attribute was hidden under define

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Using WEAK_ATTR in config.hpp file
+add_compile_definitions(USE_WEAK)
+
 # Adding dirs with methods
 add_subdirectory(amazon_s3)
 add_subdirectory(file_interaction)

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,18 +2,27 @@
 
 #include <string>
 
+// Define a macro to hide the weak attribute
+// Use this if more than one file depends on it to avoid linker errors
+#ifdef USE_WEAK
+    #define WEAK_ATTR __attribute__((weak))
+#else
+    #define WEAK_ATTR
+#endif
+
+
 namespace Config {
 
-    std::string __attribute__((weak)) ListenPort = "0.0.0.0:9999";
+    std::string WEAK_ATTR ListenPort = "0.0.0.0:9999";
 
-    std::string __attribute__((weak)) Files_directory = "/usr/src/app/build/";
+    std::string WEAK_ATTR Files_directory = "/usr/src/app/build/";
 
-    std::string __attribute__((weak)) Bucket_name = "";
+    std::string WEAK_ATTR Bucket_name = "";
 
-    std::string __attribute__((weak)) Conn = "postgresql://root:root@postgres:5432/pastebin";
+    std::string WEAK_ATTR Conn = "postgresql://root:root@postgres:5432/pastebin";
 
-    std::string __attribute__((weak)) Endpoint = "";
+    std::string WEAK_ATTR Endpoint = "";
 
-    std::string __attribute__((weak)) Redis_conn = "tcp://redis:6379";
+    std::string WEAK_ATTR Redis_conn = "tcp://redis:6379";
 
-};
+} // namespace Config


### PR DESCRIPTION
В файле `config.hpp` конструкции `__attribute__((weak))` спрятаны за `define`.
Добавлены комментарии, когда и почему это нужно использовать.