### PR TITLE
Change types of some variables to std::optional

### DIFF
--- a/src/redis/redis.hpp
+++ b/src/redis/redis.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -25,18 +26,18 @@ public:
     // insert string-string
     void insert(const std::string& key,
         const std::string& value,
-        int32_t lifeTime = -1);
+        std::optional<uint32_t> lifeTime = std::nullopt);
 
     // insert string-vector<string>
     void insert(const std::string& key,
         const std::vector<std::string>& value,
-        int32_t lifeTime = -1);
+        std::optional<uint32_t> lifeTime = std::nullopt);
 
 
     // update string-vector<string>
     void update(const std::string& key,
         const std::vector<std::string>& value,
-        int32_t lifeTime = -1);
+        std::optional<uint32_t> lifeTime = std::nullopt);
 
 
     // delete by key
@@ -45,7 +46,7 @@ public:
 
     // get T by key
     template <typename T>
-    T get(const std::string& key) = delete;
+    std::optional<T> get(const std::string& key) = delete;
 
 private:
     sw::redis::Redis redis;
@@ -53,8 +54,8 @@ private:
 
 // get for string-string
 template <>
-std::string Redis::get<std::string>(const std::string& key);
+std::optional<std::string> Redis::get<std::string>(const std::string& key);
 
 // get for string-vector<string>
 template <>
-std::vector<std::string> Redis::get<std::vector<std::string>>(const std::string& key);
+std::optional<std::vector<std::string>> Redis::get<std::vector<std::string>>(const std::string& key);

--- a/src/redis/redis_actions.cpp
+++ b/src/redis/redis_actions.cpp
@@ -7,7 +7,7 @@ RedisActions::RedisConnection RedisActions::getConnection() {
 
 bool RedisActions::insert(const std::string& key,
         const std::string& value,
-        int32_t lifeTime) {
+        std::optional<uint32_t> lifeTime) {
 
     try {
          getConnection()->insert(key, value, lifeTime);
@@ -19,7 +19,7 @@ bool RedisActions::insert(const std::string& key,
 
 bool RedisActions::insert(const std::string& key,
         const std::vector<std::string>& value,
-        int32_t lifeTime) {
+        std::optional<uint32_t> lifeTime) {
     try {
         getConnection()->insert(key, value, lifeTime);
         return true;
@@ -30,7 +30,7 @@ bool RedisActions::insert(const std::string& key,
 
 bool RedisActions::update(const std::string& key,
         const std::vector<std::string>& value,
-        int32_t lifeTime) {
+        std::optional<uint32_t> lifeTime) {
     try {
         getConnection()->update(key, value, lifeTime);
         return true;
@@ -49,8 +49,8 @@ bool RedisActions::del(const std::string& key) {
 }
 
 template <>
-std::string RedisActions::get<std::string>(const std::string& key) {
-    std::string result;
+std::optional<std::string> RedisActions::get<std::string>(const std::string& key) {
+    std::optional<std::string> result;
     try {
         result = getConnection()->get<std::string>(key);
     } catch (...) {
@@ -60,9 +60,9 @@ std::string RedisActions::get<std::string>(const std::string& key) {
 }
 
 template <>
-std::vector<std::string> RedisActions::get<std::vector<std::string>>(const std::string& key) {
+std::optional<std::vector<std::string>> RedisActions::get<std::vector<std::string>>(const std::string& key) {
 
-    std::vector<std::string> result;
+    std::optional<std::vector<std::string>> result;
     try {
         result = getConnection()->get<std::vector<std::string>>(key);
     } catch (...) {

--- a/src/redis/redis_actions.hpp
+++ b/src/redis/redis_actions.hpp
@@ -13,20 +13,20 @@ public:
 
     static bool insert(const std::string& key,
             const std::string& value,
-            int32_t lifeTime = -1);
+            std::optional<uint32_t> lifeTime = std::nullopt);
 
     static bool insert(const std::string& key,
         const std::vector<std::string>& value,
-        int32_t lifeTime = -1);
+        std::optional<uint32_t> lifeTime = std::nullopt);
 
     static bool update(const std::string& key,
         const std::vector<std::string>& value,
-        int32_t lifeTime = -1);
+        std::optional<uint32_t> lifeTime = std::nullopt);
 
     static bool del(const std::string& key);
 
     template <typename T>
-    static T get(const std::string& key) = delete;
+    static std::optional<T> get(const std::string& key) = delete;
 
 private:
     static RedisConnection getConnection();
@@ -34,7 +34,7 @@ private:
 }; // class RedisActions
 
 template <>
-std::string RedisActions::get<std::string>(const std::string& key);
+std::optional<std::string> RedisActions::get<std::string>(const std::string& key);
 
 template <>
-std::vector<std::string> RedisActions::get<std::vector<std::string>>(const std::string& key);
+std::optional<std::vector<std::string>> RedisActions::get<std::vector<std::string>>(const std::string& key);

--- a/src/redis/tests/redis_actions_test.cpp
+++ b/src/redis/tests/redis_actions_test.cpp
@@ -11,14 +11,14 @@
 
 TEST(RedisActions, writeRead) {
     try {
-        EXPECT_EQ(RedisActions::get<std::string>("key"), "");
+        EXPECT_FALSE(RedisActions::get<std::string>("key").has_value());
         RedisActions::insert("key", "newValue");
-        EXPECT_EQ(RedisActions::get<std::string>("key"), "newValue");
+        EXPECT_EQ(RedisActions::get<std::string>("key").value(), "newValue");
 
-        EXPECT_EQ(RedisActions::get<std::vector<std::string>>("vectorKey"), std::vector<std::string>());
+        EXPECT_FALSE(RedisActions::get<std::vector<std::string>>("vectorKey").has_value());
         std::vector<std::string> value = {"1"};
         RedisActions::insert("vectorKey", value);
-        EXPECT_EQ(RedisActions::get<std::vector<std::string>>("vectorKey"), value);
+        EXPECT_EQ(RedisActions::get<std::vector<std::string>>("vectorKey").value(), value);
     } catch (...) {
         FAIL();
     }
@@ -28,7 +28,7 @@ TEST(RedisActions, update) {
     try {
         std::vector<std::string> newValue = {"2"};
         RedisActions::update("vectorKey", newValue);
-        EXPECT_EQ(RedisActions::get<std::vector<std::string>>("vectorKey"), newValue);
+        EXPECT_EQ(RedisActions::get<std::vector<std::string>>("vectorKey").value(), newValue);
     } catch (...) {
         FAIL();
     }
@@ -37,10 +37,10 @@ TEST(RedisActions, update) {
 TEST(RedisActions, del) {
     try {
         RedisActions::del("key");
-        EXPECT_EQ(RedisActions::get<std::string>("key"), "");
+        EXPECT_FALSE(RedisActions::get<std::string>("key").has_value());
 
         RedisActions::del("vectorKey");
-        EXPECT_EQ(RedisActions::get<std::vector<std::string>>("vectorKey"), std::vector<std::string>());
+        EXPECT_FALSE(RedisActions::get<std::vector<std::string>>("vectorKey").has_value());
     } catch (...) {
         FAIL();
     }

--- a/src/redis/tests/redis_test.cpp
+++ b/src/redis/tests/redis_test.cpp
@@ -20,15 +20,15 @@ TEST(RedisTest, setConnection) {
 TEST(RedisTest, writeRead) {
     try {
         Redis redis("tcp://127.0.0.1:6379");
-        EXPECT_EQ(redis.get<std::string>("key"), "");
+        EXPECT_FALSE(redis.get<std::string>("key").has_value());
         redis.insert("key", "value");
-        EXPECT_EQ(redis.get<std::string>("key"), "value");
+        EXPECT_EQ(redis.get<std::string>("key").value(), "value");
 
 
-        EXPECT_EQ(redis.get<std::vector<std::string>>("vector"), std::vector<std::string>());
+        EXPECT_FALSE(redis.get<std::vector<std::string>>("vector").has_value());
         std::vector<std::string> value = {"1", "2", "3", "4", "5"};
         redis.insert("vector", value);
-        EXPECT_EQ(redis.get<std::vector<std::string>>("vector"), value);
+        EXPECT_EQ(redis.get<std::vector<std::string>>("vector").value(), value);
 
     } catch (...) {
         FAIL();
@@ -41,7 +41,7 @@ TEST(RedisTest, update) {
         std::vector<std::string> new_value = {"1", "2", "3", "4", "5"};
 
         redis.update("vector", new_value);
-        EXPECT_EQ(redis.get<std::vector<std::string>>("vector"), new_value);
+        EXPECT_EQ(redis.get<std::vector<std::string>>("vector").value(), new_value);
 
     } catch (...) {
         FAIL();
@@ -52,10 +52,10 @@ TEST(RedisTest, del) {
     try {
         Redis redis("tcp://127.0.0.1:6379");
         redis.del("vector");
-        EXPECT_EQ(redis.get<std::vector<std::string>>("vector"), std::vector<std::string>());
+        EXPECT_FALSE(redis.get<std::vector<std::string>>("vector").has_value());
 
         redis.del("key");
-        EXPECT_EQ(redis.get<std::string>("key"), "");
+        EXPECT_FALSE(redis.get<std::string>("key").has_value());
     } catch (...) {
         FAIL();
     }

--- a/src/server/methods/methods.cpp
+++ b/src/server/methods/methods.cpp
@@ -1,6 +1,6 @@
 #include "methods.hpp"
 
-std::pair<bool, std::string> PastebinMethods::addPaste(uint64_t user_id, pasteData data) {
+std::optional<std::string> PastebinMethods::addPaste(uint64_t user_id, pasteData data) {
 
     auto& [author, password, title, created_at, text] = data;
     
@@ -11,13 +11,13 @@ std::pair<bool, std::string> PastebinMethods::addPaste(uint64_t user_id, pasteDa
 
     if (PasteData::addNewPaste(private_key, zipCompression::compressString(text))) {
         updatePasteInfo(public_key, std::tuple(password, title));
-        return {true, public_key};
+        return public_key;
     }
 
-    return {false, ""};
+    return std::nullopt;
 }
 
-std::pair<bool, pasteData> PastebinMethods::getPaste(const std::string& public_key,
+std::optional<pasteData> PastebinMethods::getPaste(const std::string& public_key,
                                                      const std::string& user_password) {
 
     auto lock = KeyManager::lockKey(public_key);
@@ -25,14 +25,14 @@ std::pair<bool, pasteData> PastebinMethods::getPaste(const std::string& public_k
     auto [private_key, author, password, title, created_at] = cached_postgres::get_paste_info(public_key);
 
     if (password != user_password || private_key == "") {
-        return {false, std::tuple("", "", "", "", "")};
+        return std::nullopt;
     }
 
-    return {true, std::tuple(std::move(author),
+    return  std::tuple(std::move(author),
                        std::move(password),
                        std::move(title),
                        std::move(created_at),
-                       std::move(zipCompression::decompressString(PasteData::getCachedPaste(private_key))))};
+                       std::move(zipCompression::decompressString(PasteData::getCachedPaste(private_key))));
 }
 
 bool PastebinMethods::deletePaste(const std::string& public_key) {

--- a/src/server/methods/methods.hpp
+++ b/src/server/methods/methods.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <string>
 #include <tuple>
 
@@ -20,10 +21,10 @@ using pasteData = std::tuple<std::string, std::string, std::string, std::string,
 class PastebinMethods {
 public:
 
-    static std::pair<bool, std::string> addPaste(uint64_t user_id,
+    static std::optional<std::string> addPaste(uint64_t user_id,
                                                  pasteData data);
 
-    static std::pair<bool, pasteData> getPaste(const std::string& public_key,
+    static std::optional<pasteData> getPaste(const std::string& public_key,
                                                const std::string& user_password);
     
     static bool deletePaste(const std::string& public_key);

--- a/src/server/methods/paste_data/PasteData.cpp
+++ b/src/server/methods/paste_data/PasteData.cpp
@@ -20,7 +20,7 @@ bool PasteData::addNewPaste(const std::string& key, const std::string& pasteText
 std::string PasteData::getCachedPaste(const std::string& key) {
 
     auto cached_data_ = RedisActions::get<std::string>(key);
-    if (cached_data_ != "") return cached_data_;
+    if (cached_data_.has_value()) return cached_data_.value();
 
     bool download = AwsActions::DownloadObject(Aws::String(key + ".bin"),
                                                 Aws::String(Config::Bucket_name),

--- a/src/server/methods/redis_settings/RedisSettings.hpp
+++ b/src/server/methods/redis_settings/RedisSettings.hpp
@@ -4,6 +4,6 @@
 
 namespace redisSettins {
 
-    int32_t __attribute__((weak)) lifeTime = 600; // lifeTime in seconds
+    uint32_t __attribute__((weak)) lifeTime = 600; // lifeTime in seconds
 
 };

--- a/src/server/methods/sql_cache_interface/sql_cache_interface.cpp
+++ b/src/server/methods/sql_cache_interface/sql_cache_interface.cpp
@@ -4,18 +4,18 @@ paste_info cached_postgres::get_paste_info(const std::string& public_key) {
 
     auto info = RedisActions::get<std::vector<std::string>>(public_key);
 
-    if (info.empty()) {
+    if (!info.has_value()) {
         info = [&public_key]() { 
             paste_info info = postgres::get_paste_info(public_key);
             return std::vector<std::string>{std::get<0>(info), std::get<1>(info)
                 , std::get<2>(info), std::get<3>(info), std::get<4>(info)};
         }();
-        RedisActions::insert(public_key, info, redisSettins::lifeTime);
+        RedisActions::insert(public_key, info.value(), redisSettins::lifeTime);
     }
 
     return [&info]() {
-        return std::forward_as_tuple(std::move(info[0]), std::move(info[1])
-            , std::move(info[2]), std::move(info[3]), std::move(info[4]));
+        return std::forward_as_tuple(std::move(info.value()[0]), std::move(info.value()[1])
+            , std::move(info.value()[2]), std::move(info.value()[3]), std::move(info.value()[4]));
     }();
 };
 
@@ -25,9 +25,9 @@ void cached_postgres::change_password(const std::string& public_key, const std::
 
     auto info = RedisActions::get<std::vector<std::string>>(public_key);
 
-    if (!info.empty()) {
-        info[2] = new_password;
-        RedisActions::update(public_key, info, redisSettins::lifeTime);
+    if (info.has_value()) {
+        info.value()[2] = new_password;
+        RedisActions::update(public_key, info.value(), redisSettins::lifeTime);
     }
 }
 
@@ -37,9 +37,9 @@ void cached_postgres::change_title(const std::string& public_key, const std::str
 
     auto info = RedisActions::get<std::vector<std::string>>(public_key);
 
-    if (!info.empty()) {
-        info[3] = new_name;
-        RedisActions::update(public_key, info, redisSettins::lifeTime);
+    if (info.has_value()) {
+        info.value()[3] = new_name;
+        RedisActions::update(public_key, info.value(), redisSettins::lifeTime);
     }
 }
 
@@ -53,7 +53,7 @@ void cached_postgres::del_paste(const std::string& public_key, uint64_t login) {
     
     auto info = RedisActions::get<std::vector<std::string>>(public_key);  
 
-    if (!info.empty()) {
+    if (info.has_value()) {
         RedisActions::update(public_key, {"", "", "", "", ""}, redisSettins::lifeTime);
     }
 }

--- a/src/server/methods/tests/sql_cache_interface_tests.cpp
+++ b/src/server/methods/tests/sql_cache_interface_tests.cpp
@@ -15,12 +15,12 @@ TEST(SqlCacheInterfaceTest, GetPasteInfoExist) {
     EXPECT_EQ(expected, actual_postgres_info);
 
     auto actual_redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    ASSERT_FALSE(actual_redis_info.empty()) << "Function get_paste_info didn't insert into redis paste info";
-    EXPECT_EQ(actual_redis_info[0], std::get<0>(expected));
-    EXPECT_EQ(actual_redis_info[1], std::get<1>(expected));
-    EXPECT_EQ(actual_redis_info[2], std::get<2>(expected));
-    EXPECT_EQ(actual_redis_info[3], std::get<3>(expected));
-    EXPECT_EQ(actual_redis_info[4], std::get<4>(expected));
+    ASSERT_TRUE(actual_redis_info.has_value()) << "Function get_paste_info didn't insert into redis paste info";
+    EXPECT_EQ(actual_redis_info.value()[0], std::get<0>(expected));
+    EXPECT_EQ(actual_redis_info.value()[1], std::get<1>(expected));
+    EXPECT_EQ(actual_redis_info.value()[2], std::get<2>(expected));
+    EXPECT_EQ(actual_redis_info.value()[3], std::get<3>(expected));
+    EXPECT_EQ(actual_redis_info.value()[4], std::get<4>(expected));
     
     postgres::del_paste(key.first, login);
     RedisActions::del(key.first);
@@ -38,16 +38,16 @@ TEST(SqlCacheInterfaceTest, GetPasteInfoDidNotExist) {
     EXPECT_EQ(expected, actual_postgres_info);
 
     auto actual_redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    ASSERT_FALSE(actual_redis_info.empty()) << "Function get_paste_info didn't insert into redis paste info";
-    EXPECT_EQ(actual_redis_info[0], std::get<0>(expected));
-    EXPECT_EQ(actual_redis_info[1], std::get<1>(expected));
-    EXPECT_EQ(actual_redis_info[2], std::get<2>(expected));
-    EXPECT_EQ(actual_redis_info[3], std::get<3>(expected));
-    EXPECT_EQ(actual_redis_info[4], std::get<4>(expected));
+    ASSERT_TRUE(actual_redis_info.has_value()) << "Function get_paste_info didn't insert into redis paste info";
+    EXPECT_EQ(actual_redis_info.value()[0], std::get<0>(expected));
+    EXPECT_EQ(actual_redis_info.value()[1], std::get<1>(expected));
+    EXPECT_EQ(actual_redis_info.value()[2], std::get<2>(expected));
+    EXPECT_EQ(actual_redis_info.value()[3], std::get<3>(expected));
+    EXPECT_EQ(actual_redis_info.value()[4], std::get<4>(expected));
     
     postgres::del_paste(key.first, login);
     RedisActions::del(key.first);
-}
+} 
 
 TEST(SqlCacheInterfaceTest, ChangePasswordExist) { 
     uint64_t login = 1111;
@@ -62,7 +62,7 @@ TEST(SqlCacheInterfaceTest, ChangePasswordExist) {
     EXPECT_EQ(password, std::get<2>(postgres_info)) << "Function change_password doesn't change password in postgressql table";
 
     auto redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    EXPECT_EQ(redis_info[2], password) << "Function change_password doesn't change paste password in redis";
+    EXPECT_EQ(redis_info.value()[2], password) << "Function change_password doesn't change paste password in redis";
 
     postgres::del_paste(key.first, login);
     RedisActions::del(key.first);
@@ -80,7 +80,7 @@ TEST(SqlCacheInterfaceTest, ChangePasswordDidNotExist) {
     EXPECT_EQ(password, std::get<2>(postgres_info)) << "Function change_password doesn't change password in postgressql table";
 
     auto redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    EXPECT_TRUE(redis_info.empty()) << "Function change_password insert into redis paste info";
+    EXPECT_FALSE(redis_info.has_value()) << "Function change_password insert into redis paste info";
 
     postgres::del_paste(key.first, login);
     RedisActions::del(key.first);
@@ -99,7 +99,7 @@ TEST(SqlCacheInterfaceTest, ChangeTitleExist) {
     EXPECT_EQ(title, std::get<3>(postgres_info)) << "Function change_title doesn't change title in postgressql table";
 
     auto redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    EXPECT_EQ(redis_info[3], title) << "Function change_title doesn't change paste title in redis";
+    EXPECT_EQ(redis_info.value()[3], title) << "Function change_title doesn't change paste title in redis";
 
     postgres::del_paste(key.first, login);
     RedisActions::del(key.first);
@@ -117,7 +117,7 @@ TEST(SqlCacheInterfaceTest, ChangeTitleDidNotExist) {
     EXPECT_EQ(title, std::get<3>(postgres_info)) << "Function change_title doesn't change title in postgressql table";
 
     auto redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    EXPECT_TRUE(redis_info.empty()) << "Function change_title insert into redis paste info";
+    EXPECT_FALSE(redis_info.has_value()) << "Function change_title insert into redis paste info";
 
     postgres::del_paste(key.first, login);
 }
@@ -137,9 +137,9 @@ TEST(SqlCacheInterfaceTest, DelPasteExist) {
     }
 
     auto redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    ASSERT_TRUE(!redis_info.empty()) << "Function del_paste delete paste info in redis";
+    ASSERT_TRUE(redis_info.has_value()) << "Function del_paste delete paste info in redis";
     std::vector<std::string> expected = {"","","","",""};
-    EXPECT_EQ(redis_info, expected) << "Function del_paste didn't change paste info in redis";
+    EXPECT_EQ(redis_info.value(), expected) << "Function del_paste didn't change paste info in redis";
     RedisActions::del(key.first);
 }
 
@@ -157,8 +157,8 @@ TEST(SqlCacheInterfaceTest, DelPasteDidNotExist) {
     }
 
     auto redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    EXPECT_TRUE(redis_info.empty()) << "Function del_paste insert into redis paste info";
-    if (!redis_info.empty()) {
+    EXPECT_FALSE(redis_info.has_value()) << "Function del_paste insert into redis paste info";
+    if (redis_info.has_value()) {
         RedisActions::del(key.first);
     }
 }
@@ -174,8 +174,8 @@ TEST(SqlCacheInterfaceTest, CreatePaste) {
     EXPECT_EQ(std::get<1>(postgres_info), std::to_string(login));
 
     auto redis_info = RedisActions::get<std::vector<std::string>>(key.first);
-    EXPECT_TRUE(redis_info.empty()) << "Function create paste insert into redis paste info";
-    if (!redis_info.empty()) {
+    EXPECT_FALSE(redis_info.has_value()) << "Function create paste insert into redis paste info";
+    if (redis_info.has_value()) {
         RedisActions::del(key.first);
     }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -20,11 +20,11 @@ class ProcessImpl final : public pastebinApi::Service {
             std::tuple(std::to_string(request->user_id()), request->password(), request->title(), "", request->text()));
 
         // test act result
-        if (!result.first) {
+        if (!result.has_value()) {
             return grpc::Status(grpc::StatusCode::UNAVAILABLE, "Service is currently unavailable");
         }
 
-        response->set_public_key(std::move(result.second));
+        response->set_public_key(std::move(result.value()));
         return grpc::Status::OK;
     }
 
@@ -43,16 +43,16 @@ class ProcessImpl final : public pastebinApi::Service {
                                                 request->password());
 
         // test result data
-        if (!result.first) {
+        if (!result.has_value()) {
             return grpc::Status::CANCELLED;
         }
 
 
-        response->set_author(std::move(std::get<0>(result.second)));
-        response->set_password(std::move(std::get<1>(result.second)));
-        response->set_title(std::move(std::get<2>(result.second)));
-        response->set_created_at(std::get<3>(result.second).substr(0, 19));
-        response->set_paste_text(std::move(std::get<4>(result.second)));
+        response->set_author(std::move(std::get<0>(result.value())));
+        response->set_password(std::move(std::get<1>(result.value())));
+        response->set_title(std::move(std::get<2>(result.value())));
+        response->set_created_at(std::get<3>(result.value()).substr(0, 19));
+        response->set_paste_text(std::move(std::get<4>(result.value())));
         return grpc::Status::OK;
     }
 


### PR DESCRIPTION
Тип переменных, которые могут в одном из случаев иметь невалидное значение, заменен на std::optional. Это увеличивает читаемость и понятность кода.