### PR TITLE
Fix unclear variable name in RedisSettings.hpp

### DIFF
--- a/src/server/methods/paste_data/PasteData.cpp
+++ b/src/server/methods/paste_data/PasteData.cpp
@@ -30,7 +30,7 @@ std::string PasteData::getCachedPaste(const std::string& key) {
         auto [value, correct] = FileCommands::bin_to_string(key, Config::Files_directory);
         if (!correct) return "";
 
-        RedisActions::insert(key, value, redisSettins::lifeTime);
+        RedisActions::insert(key, value, redisSettins::lifeTimeInSeconds);
         return value;
     }
 

--- a/src/server/methods/redis_settings/RedisSettings.hpp
+++ b/src/server/methods/redis_settings/RedisSettings.hpp
@@ -4,6 +4,6 @@
 
 namespace redisSettins {
 
-    int32_t __attribute__((weak)) lifeTime = 600; // lifeTime in seconds
+    int32_t __attribute__((weak)) lifeTimeInSeconds = 600;
 
 };

--- a/src/server/methods/sql_cache_interface/sql_cache_interface.cpp
+++ b/src/server/methods/sql_cache_interface/sql_cache_interface.cpp
@@ -10,7 +10,7 @@ paste_info cached_postgres::get_paste_info(const std::string& public_key) {
             return std::vector<std::string>{std::get<0>(info), std::get<1>(info)
                 , std::get<2>(info), std::get<3>(info), std::get<4>(info)};
         }();
-        RedisActions::insert(public_key, info, redisSettins::lifeTime);
+        RedisActions::insert(public_key, info, redisSettins::lifeTimeInSeconds);
     }
 
     return [&info]() {
@@ -27,7 +27,7 @@ void cached_postgres::change_password(const std::string& public_key, const std::
 
     if (!info.empty()) {
         info[2] = new_password;
-        RedisActions::update(public_key, info, redisSettins::lifeTime);
+        RedisActions::update(public_key, info, redisSettins::lifeTimeInSeconds);
     }
 }
 
@@ -39,7 +39,7 @@ void cached_postgres::change_title(const std::string& public_key, const std::str
 
     if (!info.empty()) {
         info[3] = new_name;
-        RedisActions::update(public_key, info, redisSettins::lifeTime);
+        RedisActions::update(public_key, info, redisSettins::lifeTimeInSeconds);
     }
 }
 
@@ -54,7 +54,7 @@ void cached_postgres::del_paste(const std::string& public_key, uint64_t login) {
     auto info = RedisActions::get<std::vector<std::string>>(public_key);  
 
     if (!info.empty()) {
-        RedisActions::update(public_key, {"", "", "", "", ""}, redisSettins::lifeTime);
+        RedisActions::update(public_key, {"", "", "", "", ""}, redisSettins::lifeTimeInSeconds);
     }
 }
 


### PR DESCRIPTION
В файле `RedisSettings.hpp` изменено имя переменной `lifeTime` --> `lifeTimeInSeconds`.